### PR TITLE
[FIX] Update task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "back-to-do",
+  "name": "back-to-do-list",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "back-to-do",
+      "name": "back-to-do-list",
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {

--- a/src/modules/task/repository/task.repository.ts
+++ b/src/modules/task/repository/task.repository.ts
@@ -153,7 +153,7 @@ export class TaskRepository implements ITaskRepository {
     } = updateTaskDto;
 
     try {
-      if (categories.length) {
+      if (categories && categories.length) {
         await this.prisma.taskCategory.deleteMany({
           where: {
             task: {


### PR DESCRIPTION
Error: when updating task, if categories didn't exists, an error was thrown as `categories` were undefined.

Correction: Validate if categories exists and if it's length is greater than 0.